### PR TITLE
Tim360audit

### DIFF
--- a/contracts/Autopay.sol
+++ b/contracts/Autopay.sol
@@ -274,12 +274,12 @@ contract Autopay is UsingTellor {
         uint256 _rewardIncreasePerSecond,
         bytes calldata _queryData,
         uint256 _amount
-    ) external {
+    ) external returns(bytes32 _feedId) {
         require(
             _queryId == keccak256(_queryData) || uint256(_queryId) <= 100,
             "id must be hash of bytes data"
         );
-        bytes32 _feedId = keccak256(
+        _feedId = keccak256(
             abi.encode(
                 _queryId,
                 _reward,
@@ -311,6 +311,7 @@ contract Autopay is UsingTellor {
         if(_amount > 0){
             fundFeed(_feedId,_queryId,_amount);
         }
+        return _feedId;
     }
 
     /**

--- a/contracts/Autopay.sol
+++ b/contracts/Autopay.sol
@@ -55,7 +55,8 @@ contract Autopay is UsingTellor {
         bytes32 _queryId,
         bytes32 _feedId,
         uint256 _amount,
-        address _feedFunder
+        address _feedFunder,
+        FeedDetails _feedDetails
     );
     event NewDataFeed(
         bytes32 _queryId,
@@ -245,7 +246,7 @@ contract Autopay is UsingTellor {
             _feed.feedsWithFundingIndex = feedsWithFunding.length;
         }
         userTipsTotal[msg.sender] += _amount;
-        emit DataFeedFunded(_feedId, _queryId, _amount, msg.sender);
+        emit DataFeedFunded(_feedId, _queryId, _amount, msg.sender, _feed);
     }
 
     /**

--- a/contracts/Autopay.sol
+++ b/contracts/Autopay.sol
@@ -15,7 +15,6 @@ contract Autopay is UsingTellor {
     // Storage
     IERC20 public token; // TRB token address
     uint256 public fee; // 1000 is 100%, 50 is 5%, etc.
-    uint256 public reportingLock; // oracle reporting lock
 
     mapping(bytes32 => bytes32[]) currentFeeds; // mapping queryId to dataFeedIds array
     mapping(bytes32 => mapping(bytes32 => Feed)) dataFeed; // mapping queryId to dataFeedId to details
@@ -52,15 +51,15 @@ contract Autopay is UsingTellor {
 
     // Events
     event DataFeedFunded(
-        bytes32 _queryId,
-        bytes32 _feedId,
+        bytes32 indexed _queryId,
+        bytes32 indexed _feedId,
         uint256 _amount,
         address _feedFunder,
         FeedDetails _feedDetails
     );
     event NewDataFeed(
-        bytes32 _queryId,
-        bytes32 _feedId,
+        bytes32 indexed _queryId,
+        bytes32 indexed _feedId,
         bytes _queryData,
         address _feedCreator
     );
@@ -96,7 +95,6 @@ contract Autopay is UsingTellor {
     ) UsingTellor(_tellor) {
         token = IERC20(_token);
         fee = _fee;
-        reportingLock = tellor.reportingLock();
     }
 
     /**

--- a/contracts/Autopay.sol
+++ b/contracts/Autopay.sol
@@ -367,6 +367,9 @@ contract Autopay is UsingTellor {
      * @return amount of tip
      */
     function getCurrentTip(bytes32 _queryId) public view returns (uint256) {
+        if(tips[_queryId].length == 0){
+            return 0;
+        }
         (, uint256 _timestampRetrieved) = _getCurrentValue(_queryId);
         Tip memory _lastTip = tips[_queryId][tips[_queryId].length - 1];
         if (_timestampRetrieved < _lastTip.timestamp) {

--- a/contracts/Autopay.sol
+++ b/contracts/Autopay.sol
@@ -146,6 +146,10 @@ contract Autopay is UsingTellor {
         uint256 _cumulativeReward;
         Feed storage _feed = dataFeed[_queryId][_feedId];
         uint256 _balance = _feed.details.balance;
+        require(
+            _balance > 0,
+            "no funds available for this feed"
+        );
         for (uint256 _i = 0; _i < _timestamps.length; _i++) {
             require(
                 block.timestamp - _timestamps[_i] > 12 hours,

--- a/contracts/QueryDataStorage.sol
+++ b/contracts/QueryDataStorage.sol
@@ -15,7 +15,7 @@ contract QueryDataStorage {
      * @dev Stores query data in a mapping from queryId
      * @param _queryData The query data
      */
-    function storeData(bytes memory _queryData) public {
+    function storeData(bytes memory _queryData) external {
         bytes32 _queryId = keccak256(_queryData);
         if (queryData[_queryId].length == 0) {
             queryData[_queryId] = _queryData;

--- a/contracts/QueryDataStorage.sol
+++ b/contracts/QueryDataStorage.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.3;
+
+/**
+ @author Tellor Inc.
+ @title QueryDataStorage
+ @dev This contract is used for storing query data
+*/
+contract QueryDataStorage {
+    mapping(bytes32 => bytes) public queryData; // queryId => queryData
+
+    event QueryDataStored(bytes32 _queryId);
+
+    /**
+     * @dev Stores query data in a mapping from queryId
+     * @param _queryData The query data
+     */
+    function storeData(bytes memory _queryData) public {
+        bytes32 _queryId = keccak256(_queryData);
+        if (queryData[_queryId].length == 0) {
+            queryData[_queryId] = _queryData;
+            emit QueryDataStored(_queryId);
+        }
+    }
+
+    /**
+     * @dev Retrieves query data
+     * @param _queryId Unique identifier for the query
+     * @return _queryData Stored query data
+     */
+    function getQueryData(bytes32 _queryId)
+        public
+        view
+        returns (bytes memory _queryData)
+    {
+        return queryData[_queryId];
+    }
+}

--- a/contracts/interfaces/IQueryDataStorage.sol
+++ b/contracts/interfaces/IQueryDataStorage.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IQueryDataStorage {
+  function storeData(bytes memory _queryData) external; 
+}

--- a/contracts/testing/AutopayMock.sol
+++ b/contracts/testing/AutopayMock.sol
@@ -7,7 +7,8 @@ contract AutopayMock is Autopay {
     constructor(
         address payable _tellor,
         address _token,
-        uint256 _fee) Autopay(_tellor, _token, _fee) {}
+        address _queryDataStorage,
+        uint256 _fee) Autopay(_tellor, _token, _queryDataStorage, _fee) {}
     
     function bytesToUint(bytes memory _b) public pure returns(uint256) {
         return _bytesToUint(_b);

--- a/contracts/testing/TellorPlayground.sol
+++ b/contracts/testing/TellorPlayground.sol
@@ -32,7 +32,8 @@ contract TellorPlayground {
     mapping(address => mapping(address => uint256)) private _allowances;
     mapping(address => uint256) private _balances;
 
-    uint256 public stakeAmount;
+    uint256 public reportingLock = 12 hours;
+    uint256 public stakeAmount = 100 ether;
     uint256 public constant timeBasedReward = 5e17; // time based reward for a reporter for successfully submitting a value
     uint256 public tipsInContract; // number of tips within the contract
     uint256 public voteCount;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "dotenv": "^16.0.0",
     "hardhat-contract-sizer": "^2.4.0",
     "solidity-coverage": "^0.7.20",
-    "usingtellor": "github:tellor-io/usingtellor#360"
+    "usingtellor": "github:tellor-io/usingtellor#360audit"
   }
 }

--- a/test/e2eTests.js
+++ b/test/e2eTests.js
@@ -21,8 +21,11 @@ describe("Autopay - e2e tests", function() {
     tellor = await TellorPlayground.deploy();
     await tellor.deployed();
     await tellor.faucet(accounts[0].address);
+    const QueryDataStorage = await ethers.getContractFactory("QueryDataStorage");
+    const queryDataStorage = await QueryDataStorage.deploy();
+    await queryDataStorage.deployed();
     const Autopay = await ethers.getContractFactory("AutopayMock");
-    autopay = await Autopay.deploy(tellor.address, tellor.address, FEE);
+    autopay = await Autopay.deploy(tellor.address, tellor.address, queryDataStorage.address, FEE);
     await autopay.deployed();
   });
 

--- a/test/e2eTests.js
+++ b/test/e2eTests.js
@@ -705,7 +705,6 @@ describe("Autopay - e2e tests", function() {
     await h.expectThrow(autopay.connect(accounts[4]).claimTip(feedId1, QUERYID1, [blocky4.timestamp]))
     await h.expectThrow(autopay.connect(accounts[5]).claimTip(feedId1, QUERYID1, [blocky5.timestamp]))
     await autopay.connect(accounts[6]).claimTip(feedId1, QUERYID1, [blocky6.timestamp])
-    console.log(await tellor.balanceOf(accounts[6].address))
     expectedReward = h.toWei((1 * (1000 - FEE) / 1000).toString())
     assert(await tellor.balanceOf(accounts[6].address) == expectedReward, "autopay payout should be correct")
     
@@ -775,7 +774,6 @@ describe("Autopay - e2e tests", function() {
     await h.expectThrow(autopay.connect(accounts[1]).claimOneTimeTip(QUERYID1, [blocky1.timestamp]))
     await h.expectThrow(autopay.connect(accounts[2]).claimOneTimeTip(QUERYID1, [blocky2.timestamp]))
     await autopay.connect(accounts[3]).claimOneTimeTip(QUERYID1, [blocky3.timestamp])
-    console.log("bal: " + await tellor.balanceOf(accounts[3].address))
     reporterBal = await tellor.balanceOf(accounts[3].address)
     expectedBal = h.toWei((31 * (1000 - FEE) / 1000).toString())
     expect(reporterBal).to.equal(expectedBal)

--- a/test/e2eTests.js
+++ b/test/e2eTests.js
@@ -764,14 +764,3 @@ describe("Autopay - e2e tests", function() {
 
   })
 });
-
-// function setupDataFeed(
-//   bytes32 _queryId,
-//   uint256 _reward,
-//   uint256 _startTime,
-//   uint256 _interval,
-//   uint256 _window,
-//   uint256 _priceThreshold,
-//   uint256 _rewardIncreasePerSecond,
-//   bytes calldata _queryData,
-//   uint256 _amount

--- a/test/e2eTests.js
+++ b/test/e2eTests.js
@@ -810,4 +810,11 @@ describe("Autopay - e2e tests", function() {
     expectedTellorReward = h.toWei((200 * FEE / 1000).toString())
     expect(await tellor.balanceOf(tellor.address)).to.equal(BigInt(expectedTellorReward) + BigInt(expectedBalanceTellor))
   })
+
+  it("ensure getCurrentTip doesn't fail if no tip", async function() {
+    tipsArray = await autopay.getPastTips(QUERYID1)
+    assert(tipsArray.length == 0, "tipsArray should be empty")
+    currentTip = await autopay.getCurrentTip(QUERYID1)
+    assert(currentTip == 0, "currentTip should be 0")
+  })
 });

--- a/test/functionTests-TellorAutopay.js
+++ b/test/functionTests-TellorAutopay.js
@@ -143,8 +143,11 @@ describe("Autopay - function tests", () => {
     await h.expectThrow(autopay.setupDataFeed(QUERYID2,h.toWei("0"),blocky.timestamp,3600,600,0,0,"0x",0));//reward is zero
     await h.expectThrow(autopay.setupDataFeed(QUERYID1,h.toWei("1"),blocky.timestamp,600,600,0,0,"0x",0));//already set up
     await h.expectThrow(autopay.setupDataFeed(QUERYID2,h.toWei("1"),blocky.timestamp,600,3600,0,0,"0x",0));//interval > window
+    // first, simulate call with callStatic to retrieve feedId returned by setupDataFeed
+    feedIdRetrieved = await autopay.callStatic.setupDataFeed(QUERYID1,h.toWei("1"),firstBlocky.timestamp,3600,600,1,3,"0x",0);
     await autopay.setupDataFeed(QUERYID1,h.toWei("1"),firstBlocky.timestamp,3600,600,1,3,"0x",0);
     feedId = keccak256(abiCoder.encode(["bytes32", "uint256", "uint256", "uint256", "uint256", "uint256", "uint256"],[QUERYID1,h.toWei("1"),firstBlocky.timestamp,3600,600,1,3]));
+    assert(feedId == feedIdRetrieved, "setupDataFeed should return the feedId");
     let result = await autopay.getDataFeed(feedId);
     expect(result.reward).to.equal(h.toWei("1"))
     expect(result.balance).to.equal(0);

--- a/test/functionTests-TellorAutopay.js
+++ b/test/functionTests-TellorAutopay.js
@@ -214,10 +214,12 @@ describe("Autopay - function tests", () => {
     expect(result[6]).to.equal(0);
   });
   it("getCurrentTip", async () => {
+    let res = await autopay.getCurrentTip(QUERYID1);
+    assert(res == 0, "tip amount should be zero")
     await h.expectThrow(autopay.tip(QUERYID1,web3.utils.toWei("100"),'0x'));
     await tellor.approve(autopay.address,web3.utils.toWei("100"))
     await autopay.tip(QUERYID1,web3.utils.toWei("100"),'0x')
-    let res = await autopay.getCurrentTip(QUERYID1);
+    res = await autopay.getCurrentTip(QUERYID1);
     assert(res == web3.utils.toWei("100"), "tip should be correct")
   });
   it("getPastTips", async () => {

--- a/test/functionTests-TellorAutopay.js
+++ b/test/functionTests-TellorAutopay.js
@@ -20,8 +20,11 @@ describe("Autopay - function tests", () => {
     tellor = await TellorPlayground.deploy();
     await tellor.deployed();
     for(i=0; i<2; i++){await tellor.faucet(accounts[0].address);}
+    const QueryDataStorage = await ethers.getContractFactory("QueryDataStorage");
+    queryDataStorage = await QueryDataStorage.deploy();
+    await queryDataStorage.deployed();
     const Autopay = await ethers.getContractFactory("AutopayMock");
-    autopay = await Autopay.deploy(tellor.address, tellor.address, FEE);
+    autopay = await Autopay.deploy(tellor.address, tellor.address, queryDataStorage.address, FEE);
     await autopay.deployed();
     firstBlocky = await h.getBlock();
     await autopay.setupDataFeed(QUERYID1,h.toWei("1"),firstBlocky.timestamp,3600,600,0,0,"0x",0);

--- a/test/functionTests-TellorAutopay.js
+++ b/test/functionTests-TellorAutopay.js
@@ -130,7 +130,7 @@ describe("Autopay - function tests", () => {
     // emit DataFeedFunded(_feedId,_queryId,_amount,_feedFunder);
     await tellor.approve(autopay.address, h.toWei("100"));
     let initBal = await tellor.balanceOf(autopay.address)
-    await expect(autopay.fundFeed(bytesId, QUERYID1, h.toWei("10"))).to.emit(autopay, "DataFeedFunded").withArgs(bytesId, QUERYID1, h.toWei("10"), accounts[0].address);
+    await expect(autopay.fundFeed(bytesId, QUERYID1, h.toWei("10"))).to.emit(autopay, "DataFeedFunded").withArgs(bytesId, QUERYID1, h.toWei("10"), accounts[0].address, [web3.utils.toWei("1"), h.toWei("1010"), firstBlocky.timestamp, 3600, 600, 0, 0, 1]);
     expect(await tellor.balanceOf(autopay.address) - initBal == h.toWei("10"), "balance should change")
   });
   


### PR DESCRIPTION
- fixed bug where disputed reporter could claim one time tips https://github.com/tellor-io/autoPay/issues/53
- installed usingtellor from 360 branch 
- emit FeedDetails in DataFeedFunded event https://github.com/tellor-io/autoPay/issues/54
- cap one time tips and auto rewards at stake amount https://github.com/tellor-io/autoPay/issues/51
- add queryData storage contract, store queryData in `setupDataFeed` and `tip` functions https://github.com/tellor-io/autoPay/issues/49 https://github.com/tellor-io/autoPay/issues/56
- return feedId from setupDataFeed https://github.com/tellor-io/autoPay/issues/57
- ensure getCurrentTip doesn't fail if no tips https://github.com/tellor-io/autoPay/issues/55