### PR TITLE
Get timestamps list by query id and start/end indices

### DIFF
--- a/contracts/Autopay.sol
+++ b/contracts/Autopay.sol
@@ -578,6 +578,21 @@ contract Autopay is UsingTellor {
         }
         return _status;
     }
+    /**
+    @dev Getter function for retrieving a timestamps list by queryId and Index
+    @param _start first index
+    @param _end last index
+    @return tuple of uint256 timestamps
+    */
+
+    function getTimestampsListbyQueryIdandIndex(bytes32 _queryId, uint256 _start, uint256 _end) external view returns (uint256[] memory) {
+        uint256[] memory _stamps = new uint256[]((_end - _start)+1);
+        for (uint i = 0; i <= ((_end - _start)); i++){
+            uint256 _timestamp = getTimestampbyQueryIdandIndex(_queryId, _start+i);
+            _stamps[i] = _timestamp;
+        }
+        return _stamps;
+    }
 
     /**
      * @dev Getter function for retrieving the total amount of tips paid by a given address

--- a/contracts/Autopay.sol
+++ b/contracts/Autopay.sol
@@ -578,6 +578,7 @@ contract Autopay is UsingTellor {
         }
         return _status;
     }
+
     /**
     @dev Getter function for retrieving a timestamps list by queryId and Index
     @param _start first index
@@ -585,10 +586,14 @@ contract Autopay is UsingTellor {
     @return tuple of uint256 timestamps
     */
 
-    function getTimestampsListbyQueryIdandIndex(bytes32 _queryId, uint256 _start, uint256 _end) external view returns (uint256[] memory) {
-        uint256[] memory _stamps = new uint256[]((_end - _start)+1);
-        for (uint i = 0; i <= ((_end - _start)); i++){
-            uint256 _timestamp = getTimestampbyQueryIdandIndex(_queryId, _start+i);
+    function getTimestampsListbyQueryIdandIndex(
+        bytes32 _queryId,
+        uint256 _start,
+        uint256 _end
+    ) external view returns (uint256[] memory) {
+        uint256[] memory _stamps = new uint256[]((_end - _start) + 1);
+        for (uint256 i = _start; i <= ((_end - _start)); i++) {
+            uint256 _timestamp = getTimestampbyQueryIdandIndex(_queryId, i);
             _stamps[i] = _timestamp;
         }
         return _stamps;

--- a/test/functionTests-TellorAutopay.js
+++ b/test/functionTests-TellorAutopay.js
@@ -683,4 +683,35 @@ describe("Autopay - function tests", () => {
     assert(res[1] == true)
     assert(res[2] == true)
   })
+  it("getTimestampsListbyQueryIdandIndex", async() => {
+    // submit to feeds
+    let blocky = await h.getBlock();
+    timestamp0 = blocky.timestamp;
+    await tellor.submitValue(TRB_QUERY_ID, h.uintTob32(3500), 0, TRB_QUERY_DATA);
+    blocky = await h.getBlock();
+    timestamp1 = blocky.timestamp;
+    h.advanceTime(3600);
+    await tellor.connect(accounts[0]).submitValue(TRB_QUERY_ID, h.uintTob32(3525), 1, TRB_QUERY_DATA);
+    blocky = await h.getBlock();
+    timestamp2 = blocky.timestamp;
+    h.advanceTime(3600);
+    await tellor.connect(accounts[0]).submitValue(TRB_QUERY_ID, h.uintTob32(3550), 2, TRB_QUERY_DATA);
+    blocky = await h.getBlock();
+    timestamp3 = blocky.timestamp;
+    h.advanceTime(3600);
+    await tellor.connect(accounts[0]).submitValue(TRB_QUERY_ID, h.uintTob32(3550), 3, TRB_QUERY_DATA);
+    blocky = await h.getBlock();
+    timestamp4 = blocky.timestamp;
+    h.advanceTime(3600);
+    await tellor.connect(accounts[0]).submitValue(TRB_QUERY_ID, h.uintTob32(3550), 4, TRB_QUERY_DATA);
+    blocky = await h.getBlock();
+    timestamp5 = blocky.timestamp;
+    let startIndex = await autopay.getIndexForDataBefore(TRB_QUERY_ID, timestamp0);
+    let endIndex = await autopay.getIndexForDataBefore(TRB_QUERY_ID, timestamp5);
+    let res = await autopay.getTimestampsListbyQueryIdandIndex(TRB_QUERY_ID, BigInt(startIndex[1]), BigInt(endIndex[1]));
+    assert(res[0] == timestamp1, "should be correct first submission timestamp");
+    assert(res[1] == timestamp2, "should be correct second submission timestamp");
+    assert(res[2] == timestamp3, "should be correct third sumbission timestamp");
+    assert(res[3] == timestamp4, "should be correct fourth submission timestamp");
+  });
 });


### PR DESCRIPTION
- add a getTimestampsListbyQueryIdandIndex getter that retrieves a list of timestamps between two index numbers.
- added a function test with four submissions asserting that they are retrieved by the function getter.